### PR TITLE
Fix logical errors and improve packet validation

### DIFF
--- a/src/Long.Kernel/Managers/RoleManager.cs
+++ b/src/Long.Kernel/Managers/RoleManager.cs
@@ -104,17 +104,17 @@ namespace Long.Kernel.Managers
                 return false;
             }
 
-            //if (isMaintenanceEntrance)
-            //{
-            //    await user.DisconnectWithMessageAsync(MsgConnectEx.RejectionCode.ServerLocked);
-            //    return false;
-            //}
+            if (isMaintenanceEntrance)
+            {
+                await user.DisconnectWithMessageAsync(MsgConnectEx.RejectionCode.ServerLocked);
+                return false;
+            }
 
-            //if (isCooperatorMode)
-            //{
-            //    await user.DisconnectWithMessageAsync(MsgConnectEx.RejectionCode.NonCooperatorAccount);
-            //    return false;
-            //}
+            if (isCooperatorMode)
+            {
+                await user.DisconnectWithMessageAsync(MsgConnectEx.RejectionCode.NonCooperatorAccount);
+                return false;
+            }
 
             if (userSet.TryGetValue(user.Character.Identity, out Character concurrent))
             {

--- a/src/Long.Kernel/States/Items/Drops/DropRule.cs
+++ b/src/Long.Kernel/States/Items/Drops/DropRule.cs
@@ -1,4 +1,5 @@
-﻿using Long.Database.Entities;
+using Long.Database.Entities;
+using Long.Kernel.Service;
 
 namespace Long.Kernel.States.Items.Drops
 {
@@ -64,7 +65,7 @@ namespace Long.Kernel.States.Items.Drops
             {
                 if (rand < totalChance + RuleChance)
                 {
-                    typeId = items[NextAsync(items.Count).GetAwaiter().GetResult()];
+                    typeId = items[Services.Randomness.NextInteger(0, items.Count)];
                 }
             }
 

--- a/src/Long.Kernel/States/Items/Drops/DropRuleGroup.cs
+++ b/src/Long.Kernel/States/Items/Drops/DropRuleGroup.cs
@@ -1,4 +1,5 @@
-﻿using Long.Kernel.Database.Repositories;
+using Long.Kernel.Database.Repositories;
+using Long.Kernel.Service;
 
 namespace Long.Kernel.States.Items.Drops
 {
@@ -61,7 +62,7 @@ namespace Long.Kernel.States.Items.Drops
         public uint GetDropItem()
         {
             uint typeId = 0;
-            int rand = NextAsync(DROP_CHANCE_PRECISION).GetAwaiter().GetResult();
+            int rand = Services.Randomness.NextInteger(0, DROP_CHANCE_PRECISION);
             int totalChance = 0;
             foreach (var rule in rules)
             {

--- a/src/Long.Network/NetworkDefinition.cs
+++ b/src/Long.Network/NetworkDefinition.cs
@@ -21,14 +21,15 @@ namespace Long.Network
                 return ipAddress.Equals(CIDRmask);
             }
 
+            int prefixLength = int.Parse(parts[1]);
             int ipAddr = BitConverter.ToInt32(IPAddress.Parse(ipAddress).GetAddressBytes(), 0);
             int cidrAddr = BitConverter.ToInt32(IPAddress.Parse(parts[0]).GetAddressBytes(), 0);
-            int cidrMask = IPAddress.HostToNetworkOrder(-1 << (32 - int.Parse(parts[1])));
-            if (cidrMask == 32)
+            int cidrMask = IPAddress.HostToNetworkOrder(-1 << (32 - prefixLength));
+            if (prefixLength == 32)
             {
                 return true;
             }
-            return ((ipAddr & cidrMask) == (cidrAddr & cidrMask));
+            return (ipAddr & cidrMask) == (cidrAddr & cidrMask);
         }
     }
 }

--- a/src/Long.Network/Sockets/TcpServerListener.cs
+++ b/src/Long.Network/Sockets/TcpServerListener.cs
@@ -114,7 +114,6 @@ namespace Long.Network.Sockets
 
             // Start the background registry cleaner and accepting clients
             await registry.StartAsync(shutdownToken.Token);
-            _ = packetProcessor.StartAsync(shutdownToken.Token);
             await AcceptingAsync();
         }
 
@@ -429,7 +428,15 @@ namespace Long.Network.Sockets
                     break;
                 }
 
-                // TODO add footer validation?
+                if (footerLength > 0)
+                {
+                    var footerSpan = buffer.Slice(consumed + length, footerLength);
+                    if (!footerSpan.SequenceEqual(actor.PacketFooter))
+                    {
+                        return false;
+                    }
+                }
+
                 Received(actor, buffer.Slice(consumed, length)); // skip the footer
                 consumed += length + footerLength;
             }

--- a/src/Long.Shared/Helpers/Logger.cs
+++ b/src/Long.Shared/Helpers/Logger.cs
@@ -25,6 +25,8 @@ namespace Long.Shared.Helpers
                 .WriteTo.File($"Logs/{fileName}.log", outputTemplate: "{Timestamp:HH:mm:ss.fff} [{Level}] ({ThreadId}) {Message}{NewLine}{Exception}{NewLine}", rollingInterval: RollingInterval.Day)
                 .CreateLogger();
 
+            initialized = true;
+
         }
 
         public static ILogger CreateLogger(string fileName)


### PR DESCRIPTION
## Summary
- correct CIDR range calculation
- start packet processor only once
- validate packet footers when splitting
- set logger initialization flag
- enforce maintenance and cooperator login rules
- remove blocking random calls for drops

## Testing
- `dotnet build Long.sln`

------
https://chatgpt.com/codex/tasks/task_e_684da6c0899c8323af0697dfeef6a24a